### PR TITLE
Change java package name option

### DIFF
--- a/api.proto
+++ b/api.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package proto;
 
-option java_package = "liftbridge.proto";
+option java_package = "io.liftbridge.proto";
 
 // CreateStreamRequest is sent to create a new stream.
 message CreateStreamRequest {


### PR DESCRIPTION
Since it's more common to add the TLD to the package.